### PR TITLE
chore: drop the deprecated husky shim from the git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint -g commitlint.config.js --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Summary
- Removes the husky v8 shim lines from the git hooks; husky 9 warns about them and drops support in v10.

## Test plan
- [x] A local commit with the hooks installed runs without the deprecation warning
- [ ] PR check
